### PR TITLE
docs: IntelliJ & VSCode -> go to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ Next, add the following plugin definition and configuration to your
 That's all! The AppMap agent will automatically record your tests when you run
 `gradle appmap test`. By default, AppMap files are output to `$buildDir/appmap`.
 
-Using Visual Studio Code?
-[Download the AppMap extension](https://marketplace.visualstudio.com/items?itemName=appland.appmap)
-to view AppMap files in your IDE.
+Using IntelliJ IDEA or Visual Studio Code?
+[Open the Quickstart guide](https://appland.com/docs/quickstart) and install the AppMap extension to view AppMap files in your IDE.
 
 ## About
 


### PR DESCRIPTION
Chaging the download link for VSCode to a link to the Quickstart guide for both IntelliJ and VSCode.