### PR TITLE
fix: to be able to config gradle plugin from a kotlin .kts script

### DIFF
--- a/src/main/java/com/appland/appmap/AppmapPluginExtension.java
+++ b/src/main/java/com/appland/appmap/AppmapPluginExtension.java
@@ -97,6 +97,18 @@ public class AppmapPluginExtension {
     return configFile;
   }
 
+  public void setConfigFile(RegularFileProperty configFile) {
+    this.configFile = configFile;
+  }
+
+  public void setOutputDirectory(DirectoryProperty outputDirectory) {
+    this.outputDirectory = outputDirectory;
+  }
+
+  public boolean isSkip() {
+    return skip;
+  }
+
   public boolean isConfigFileValid() {
     return configFile.get().getAsFile().exists() && Files
         .isReadable(configFile.get().getAsFile().toPath());

--- a/src/main/java/com/appland/appmap/AppmapPluginExtension.java
+++ b/src/main/java/com/appland/appmap/AppmapPluginExtension.java
@@ -105,10 +105,6 @@ public class AppmapPluginExtension {
     this.outputDirectory = outputDirectory;
   }
 
-  public boolean isSkip() {
-    return skip;
-  }
-
   public boolean isConfigFileValid() {
     return configFile.get().getAsFile().exists() && Files
         .isReadable(configFile.get().getAsFile().toPath());

--- a/src/main/java/com/appland/appmap/AppmapPluginExtension.java
+++ b/src/main/java/com/appland/appmap/AppmapPluginExtension.java
@@ -105,6 +105,10 @@ public class AppmapPluginExtension {
     this.outputDirectory = outputDirectory;
   }
 
+  public boolean isSkip() {
+    return skip;
+  }
+
   public boolean isConfigFileValid() {
     return configFile.get().getAsFile().exists() && Files
         .isReadable(configFile.get().getAsFile().toPath());


### PR DESCRIPTION
@ptrdvrk sadly I still can not manage to config the Gradle plugin from a kotlin script build file.

And since there is a known error related to using the plugin from within the local repo, I believe we need to deploy this before actually seeing it working locally, Is a bad trial and error issue, but I think is necessary. 