### PR TITLE
fix: Add backward compatibility for Gradle 5.0

### DIFF
--- a/src/main/java/com/appland/appmap/gradle/AgentCommandLineLoader.java
+++ b/src/main/java/com/appland/appmap/gradle/AgentCommandLineLoader.java
@@ -54,7 +54,7 @@ public class AgentCommandLineLoader implements CommandLineArgumentProvider, Name
     if (!appmap.isConfigFileValid()) {
       appmap.setSkip(true);
       throw new GradleException("Configuration file must exist and be readable: "
-          + appmap.getConfigFile().get().getAsFile().getPath());
+          + appmap.getConfigFilePath());
     }
     if (appmap.shouldSkip()) {
       LOGGER.warn("AppMap task was executed but but is disabled, 'skip' property set to " + appmap
@@ -70,9 +70,9 @@ public class AgentCommandLineLoader implements CommandLineArgumentProvider, Name
       argumentLn.add(javaAgentArg);
 
       if ( appmap.getConfigFile().isPresent() ) {
-        argumentLn.add("-Dappmap.config.file=" + appmap.getConfigFile().get());
+        argumentLn.add("-Dappmap.config.file=" + appmap.getConfigFilePath());
       }
-      argumentLn.add("-Dappmap.output.directory=" + appmap.getOutputDirectory().get());
+      argumentLn.add("-Dappmap.output.directory=" + appmap.getOutputDirectoryPath());
       argumentLn.add("-Dappmap.event.valueSize=" + appmap.getEventValueSize());
       argumentLn.addAll(buildDebugParams());
       LOGGER.lifecycle("Arguments line set to " + Joiner.on(",").join(argumentLn));
@@ -100,7 +100,7 @@ public class AgentCommandLineLoader implements CommandLineArgumentProvider, Name
 
       if (hasDebug) {
         debugArgs.add(0, "-Dappmap.debug.file=" + StringEscapeUtils
-            .escapeJava(format("%s", appmap.getDebugFile())));
+            .escapeJava(format("%s", appmap.getDebugFilePath())));
       }
     }
     return debugArgs;

--- a/src/main/java/com/appland/appmap/gradle/AppMapPluginExtension.java
+++ b/src/main/java/com/appland/appmap/gradle/AppMapPluginExtension.java
@@ -15,7 +15,7 @@ import org.gradle.api.tasks.Input;
  */
 public class AppMapPluginExtension {
 
-  public static final String DEFAULT_OUTPUT_DIRECTORY = "build/appmap";
+  public static final String DEFAULT_OUTPUT_DIRECTORY = "appmap";
   protected final Project project;
   private final Logger logger = Logger.getLogger("com.appland.appmap.gradle");
   private final Configuration agentConf;
@@ -38,11 +38,12 @@ public class AppMapPluginExtension {
   public AppMapPluginExtension(Project project, Configuration agentConf) {
     this.project = project;
     this.agentConf = agentConf;
-    this.configFile = project.getObjects().fileProperty().fileValue(new File("appmap.yml"));
+    this.configFile = project.getObjects().fileProperty()
+        .value(project.getLayout().getProjectDirectory().file("appmap.yml"));
     this.outputDirectory = project.getObjects().directoryProperty()
-        .fileValue(new File(DEFAULT_OUTPUT_DIRECTORY));
+        .value(project.getLayout().getBuildDirectory().dir(DEFAULT_OUTPUT_DIRECTORY).get());
     this.debugFile = project.getObjects().fileProperty()
-        .fileValue(new File("build/appmap/agent.log"));
+        .value(project.getLayout().getBuildDirectory().file("appmap/agent.log").get());
     logger.info("AppMap Plugin Initialized.");
   }
 
@@ -71,6 +72,10 @@ public class AppMapPluginExtension {
     return debugFile;
   }
 
+  public String getDebugFilePath() {
+    return debugFile.getAsFile().get().getAbsolutePath();
+  }
+
   public void setDebugFile(RegularFileProperty debugFile) {
     this.debugFile = debugFile;
   }
@@ -87,12 +92,16 @@ public class AppMapPluginExtension {
     return outputDirectory;
   }
 
-  public String getOutputDirectoryAsString() {
-    return outputDirectory.toString();
+  public String getOutputDirectoryPath() {
+    return outputDirectory.getAsFile().get().getAbsolutePath();
   }
 
   public RegularFileProperty getConfigFile() {
     return configFile;
+  }
+
+  public String getConfigFilePath() {
+    return configFile.getAsFile().get().getAbsolutePath();
   }
 
   public void setConfigFile(RegularFileProperty configFile) {


### PR DESCRIPTION
The `fileValue` method did not yet exist in Gradle 5.0. By replacing it, we're able to stretch our compatibility matrix to Gradle 5.0 and above.